### PR TITLE
Add content-security-policy & permissions-policy headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,23 @@ const nextConfig = {
         serverActions: {
             bodySizeLimit: '10mb'
         }
+    },
+    async headers() {
+        return [
+            {
+                source: "^",
+                headers: [
+                    {
+                       key: "Content-Security-Policy",
+                       value: process.env.CSP_HEADER_VALUE || "default-src 'self'; frame-ancestors 'none'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:",
+                    },
+                    {
+                      key: "Permissions-Policy",
+                      value: process.env.PERMISSIONS_POLICY_HEADER_VALUE || "camera=(), microphone=(), geolocation=()",
+                    }
+                ]
+            }
+	]
     }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
     async headers() {
         return [
             {
-                source: "^",
+                source: "/(.*)",
                 headers: [
                     {
                        key: "Content-Security-Policy",


### PR DESCRIPTION
`Content-Security-Policy`'s `frame-ancestors` directive obsoletes `X-Frame-Options`. According to https://caniuse.com/?search=frame-ancestors, the last major browser to not support it is Edge 14 from 2016. So for simplicity let's rely on in the newer header, instead of specifying the same policy twice via both the old and new headers.